### PR TITLE
Scale images based on Pandoc classes

### DIFF
--- a/source/common/modules/markdown-editor/plugins/render-images.ts
+++ b/source/common/modules/markdown-editor/plugins/render-images.ts
@@ -63,6 +63,21 @@ const img404 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAUAAAAC0CAYAAADl5P
       let title = match[3] ?? altText // An optional title in quotes after the image
       let p4 = match[4] ?? ''
 
+      let widthAttribute = ''
+      let heightAttribute = ''
+      if (match[4] !== '') {
+        let widthRE = /(width=)"([^"]+)"/g
+        let heightRE = /(height=)"([^"]+)"/g
+        let mat = widthRE.exec(p4)
+        if (mat != null) {
+          widthAttribute = mat[2] ?? ''
+        }
+        mat = heightRE.exec(p4)
+        if (mat != null) {
+          heightAttribute = mat[2] ?? ''
+        }
+      }
+
       // If a third group has been captured, we need to extract this from the
       // "bigger" second group again.
       if (match[3] !== undefined) {
@@ -161,6 +176,12 @@ const img404 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAUAAAAC0CAYAAADl5P
       let width = (!Number.isNaN(maxPreviewWidth)) ? `${maxPreviewWidth}%` : '100%'
       let height = (!Number.isNaN(maxPreviewHeight) && maxPreviewHeight < 100) ? `${maxPreviewHeight}vh` : ''
 
+      if (widthAttribute !== '') {
+        width = widthAttribute
+      }
+      if (heightAttribute !== '') {
+        height = heightAttribute
+      }
       // Apply the constraints to the figure and image
       figure.style.maxWidth = width
       figure.style.maxHeight = height

--- a/source/common/modules/markdown-editor/plugins/render-images.ts
+++ b/source/common/modules/markdown-editor/plugins/render-images.ts
@@ -155,7 +155,6 @@ const img404 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAUAAAAC0CAYAAADl5P
       caption.addEventListener('focusout', updateCaptionFunction)
 
       // Retrieve the size constraints
-      
       // Seems to Change Codes here to control image size
       const maxPreviewWidth = Number((cm as any).getOption('zettlr').imagePreviewWidth)
       const maxPreviewHeight = Number((cm as any).getOption('zettlr').imagePreviewHeight)

--- a/source/common/modules/markdown-editor/plugins/render-images.ts
+++ b/source/common/modules/markdown-editor/plugins/render-images.ts
@@ -155,6 +155,8 @@ const img404 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAUAAAAC0CAYAAADl5P
       caption.addEventListener('focusout', updateCaptionFunction)
 
       // Retrieve the size constraints
+      
+      // Seems to Change Codes here to control image size
       const maxPreviewWidth = Number((cm as any).getOption('zettlr').imagePreviewWidth)
       const maxPreviewHeight = Number((cm as any).getOption('zettlr').imagePreviewHeight)
       let width = (!Number.isNaN(maxPreviewWidth)) ? `${maxPreviewWidth}%` : '100%'


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR is for scale images in issue #1328. Documents imported with pandoc usually contain image size information, such as:
`![](image1.png){width="3.69in" height="1.93884in"}`
So just parse the information in braces and pass it to the corresponding attribute
## Changes

- parse the parameters in the braces and pass them to image.style.maxWidth attribute


## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

Tested on: macOS 12.4 Monterey Apple Silicon
